### PR TITLE
Support distinct select queries

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -332,9 +332,10 @@ PostgreSQL.prototype.buildSelect = function(model, filter, options = {}, count =
     }
   }
 
+  const distinct = options.distinct ? 'distinct ' : '';
   const selectSql = count ?
-    'count(' + this.tableEscaped(model) + '.' + this.idNames(model) + ') as "cnt"' :
-    this.buildColumnNames(model, filter, true);
+    'count(' + distinct + this.tableEscaped(model) + '.' + this.idNames(model) + ') as "cnt"' :
+    distinct + this.buildColumnNames(model, filter, true);
 
   let selectStmt = new ParameterizedSQL(
     'SELECT ' +


### PR DESCRIPTION
This will help resolve [TRM-19](https://jira.brown.edu/browse/TRM-19). This fork of `loopback-connector-postgresql` includes a customization for doing inner joins. This provides the ability to support `where` and `order by` clauses in joined tables. Now that we have multiple beds per room, this results in rooms appearing multiple times in queries that make use of this inner join feature. To address that, this PR adds the ability to specify `{ distinct: true }` as an option to any `findX` query in order to remove duplicates from the result set. We need to do this at query time (instead of when processing results) because of pagination on the frontend.

I don't really like customizing this library, but we are already depending on a [significant customization](https://github.com/BrownUniversity/loopback-connector-postgresql/commit/f2a347eaa01ed2214e82a0c6d05dadb67f6c7f14) for the inner join support, which makes merging upstream changes non-trivial. The unfortunate reality is that Loopback v4 is still half-baked. I don't see a better alternative at the moment.

Note that TRM is not actually using this fork right now. It's using the fork that we are forking. So we'll need to change that in order to take advantage of these changes.